### PR TITLE
add header with old sensor naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 
+## [1.1.1] - 2024-12-05
+
+- Compatibility header for old name SensirionI2CSht4x
+
 ## [1.1.0] - 2024-4-10
 
-### Fixed
+### Changed
+- Naming updated: SensirionI2CSht4x is now SensirionI2cSht4x (note case change for I2c)
 
+### Fixed
 - Fix colliding definitions with other Sensirion sensor drivers
+
+
 ## [1.0.0] - 2024-3-14
 
 ### Changed

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion I2C SHT4x
-version=1.1.0
+version=1.1.1
 author=Sensirion
 maintainer=Sensirion
 sentence=Library for the SHT4X sensor family by Sensirion

--- a/src/SensirionI2CSht4x.h
+++ b/src/SensirionI2CSht4x.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRIONI2CSHT4X_COMPAT_H
+#define SENSIRIONI2CSHT4X_COMPAT_H
+
+#include <SensirionI2cSht4x.h>
+
+typedef SensirionI2cSht4x SensirionI2CSht4x;
+
+#endif // SENSIRIONI2CSHT4X_COMPAT_H


### PR DESCRIPTION
SensirionI2CSht4x was changed to SensirionI2cSht4x in version 1.1.0

this commit adds a compatibility header for name as in version 1.0.0