### PR TITLE
refactor: modernize SensirionI2cSht4x code style and fix implicit conversions

### DIFF
--- a/src/SensirionI2cSht4x.cpp
+++ b/src/SensirionI2cSht4x.cpp
@@ -66,17 +66,11 @@ SensirionI2cSht4x::SensirionI2cSht4x() {
 }
 
 float SensirionI2cSht4x::signalTemperature(uint16_t temperatureTicks) {
-    float temperature = 0.0;
-    temperature = (float)(temperatureTicks);
-    temperature = ((temperature * 175.0) / 65535.0) - 45.0;
-    return temperature;
+    return (temperatureTicks * 175.0f / 65535.0f) - 45.0f;
 }
 
 float SensirionI2cSht4x::signalHumidity(uint16_t humidityTicks) {
-    float humidity = 0.0;
-    humidity = (float)(humidityTicks);
-    humidity = ((humidity * 125.0) / 65535.0) - 6.0;
-    return humidity;
+    return (humidityTicks * 125.0f / 65535.0f) - 6.0f;
 }
 
 int16_t SensirionI2cSht4x::measureHighPrecision(float& aTemperature,

--- a/src/SensirionI2cSht4x.cpp
+++ b/src/SensirionI2cSht4x.cpp
@@ -37,8 +37,8 @@
  */
 
 #include "SensirionI2cSht4x.h"
-#include <SensirionCore.h>
 #include <Arduino.h>
+#include <SensirionCore.h>
 
 enum SHT4xCmdId : uint8_t {
     SHT4X_MEASURE_HIGH_PRECISION_TICKS_CMD_ID = 0xfd,
@@ -203,8 +203,8 @@ int16_t SensirionI2cSht4x::measureHighPrecisionTicks(uint16_t& temperatureTicks,
                                                      uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_HIGH_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_MEASURE_HIGH_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -227,8 +227,8 @@ SensirionI2cSht4x::measureMediumPrecisionTicks(uint16_t& temperatureTicks,
                                                uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_MEDIUM_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_MEASURE_MEDIUM_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -251,8 +251,8 @@ SensirionI2cSht4x::measureLowestPrecisionTicks(uint16_t& temperatureTicks,
                                                uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_LOWEST_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_MEASURE_LOWEST_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -274,8 +274,8 @@ int16_t SensirionI2cSht4x::activateHighestHeaterPowerLongTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -297,8 +297,8 @@ int16_t SensirionI2cSht4x::activateHighestHeaterPowerShortTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -320,8 +320,8 @@ int16_t SensirionI2cSht4x::activateMediumHeaterPowerLongTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -343,8 +343,8 @@ int16_t SensirionI2cSht4x::activateMediumHeaterPowerShortTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -366,8 +366,8 @@ int16_t SensirionI2cSht4x::activateLowestHeaterPowerLongTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_LOWEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_LOWEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -389,8 +389,8 @@ int16_t SensirionI2cSht4x::activateLowestHeaterPowerShortTicks(
     uint16_t& temperatureTicks, uint16_t& humidityTicks) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_LOWEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_ACTIVATE_LOWEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -411,8 +411,8 @@ int16_t SensirionI2cSht4x::activateLowestHeaterPowerShortTicks(
 int16_t SensirionI2cSht4x::serialNumber(uint32_t& serialNumber) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_SERIAL_NUMBER_CMD_ID, buffer_ptr, 6);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_SERIAL_NUMBER_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -432,8 +432,8 @@ int16_t SensirionI2cSht4x::serialNumber(uint32_t& serialNumber) {
 int16_t SensirionI2cSht4x::softReset() {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
-    SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_SOFT_RESET_CMD_ID, buffer_ptr, 2);
+    SensirionI2CTxFrame txFrame = SensirionI2CTxFrame::createWithUInt8Command(
+        SHT4X_SOFT_RESET_CMD_ID, buffer_ptr, 2);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {

--- a/src/SensirionI2cSht4x.cpp
+++ b/src/SensirionI2cSht4x.cpp
@@ -40,7 +40,7 @@
 #include <SensirionCore.h>
 #include <Arduino.h>
 
-typedef enum {
+enum SHT4xCmdId : uint8_t {
     SHT4X_MEASURE_HIGH_PRECISION_TICKS_CMD_ID = 0xfd,
     SHT4X_MEASURE_MEDIUM_PRECISION_TICKS_CMD_ID = 0xf6,
     SHT4X_MEASURE_LOWEST_PRECISION_TICKS_CMD_ID = 0xe0,
@@ -52,7 +52,7 @@ typedef enum {
     SHT4X_ACTIVATE_LOWEST_HEATER_POWER_SHORT_TICKS_CMD_ID = 0x15,
     SHT4X_SERIAL_NUMBER_CMD_ID = 0x89,
     SHT4X_SOFT_RESET_CMD_ID = 0x94,
-} SHT4xCmdId;
+};
 
 // make sure that we use the proper definition of NO_ERROR
 #ifdef NO_ERROR
@@ -204,7 +204,7 @@ int16_t SensirionI2cSht4x::measureHighPrecisionTicks(uint16_t& temperatureTicks,
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0xfd, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_HIGH_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -228,7 +228,7 @@ SensirionI2cSht4x::measureMediumPrecisionTicks(uint16_t& temperatureTicks,
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0xf6, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_MEDIUM_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -252,7 +252,7 @@ SensirionI2cSht4x::measureLowestPrecisionTicks(uint16_t& temperatureTicks,
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0xe0, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_MEASURE_LOWEST_PRECISION_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -275,7 +275,7 @@ int16_t SensirionI2cSht4x::activateHighestHeaterPowerLongTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x39, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -298,7 +298,7 @@ int16_t SensirionI2cSht4x::activateHighestHeaterPowerShortTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x32, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_HIGHEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -321,7 +321,7 @@ int16_t SensirionI2cSht4x::activateMediumHeaterPowerLongTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x2f, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -344,7 +344,7 @@ int16_t SensirionI2cSht4x::activateMediumHeaterPowerShortTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x24, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_MEDIUM_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -367,7 +367,7 @@ int16_t SensirionI2cSht4x::activateLowestHeaterPowerLongTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x1e, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_LOWEST_HEATER_POWER_LONG_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -390,7 +390,7 @@ int16_t SensirionI2cSht4x::activateLowestHeaterPowerShortTicks(
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x15, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_ACTIVATE_LOWEST_HEATER_POWER_SHORT_TICKS_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -412,7 +412,7 @@ int16_t SensirionI2cSht4x::serialNumber(uint32_t& serialNumber) {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x89, buffer_ptr, 6);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_SERIAL_NUMBER_CMD_ID, buffer_ptr, 6);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {
@@ -433,7 +433,7 @@ int16_t SensirionI2cSht4x::softReset() {
     int16_t localError = NO_ERROR;
     uint8_t* buffer_ptr = communication_buffer;
     SensirionI2CTxFrame txFrame =
-        SensirionI2CTxFrame::createWithUInt8Command(0x94, buffer_ptr, 2);
+        SensirionI2CTxFrame::createWithUInt8Command(SHT4X_SOFT_RESET_CMD_ID, buffer_ptr, 2);
     localError =
         SensirionI2CCommunication::sendFrame(_i2cAddress, txFrame, *_i2cBus);
     if (localError != NO_ERROR) {

--- a/src/SensirionI2cSht4x.h
+++ b/src/SensirionI2cSht4x.h
@@ -50,6 +50,7 @@ constexpr uint8_t SHT45_I2C_ADDR_45 = 0x45;
 
 class SensirionI2cSht4x {
     using TwoWire = decltype(Wire);
+
   public:
     SensirionI2cSht4x();
     /**
@@ -208,10 +209,10 @@ class SensirionI2cSht4x {
      *
      * SHT4x command for a single shot measurement with high repeatability.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -223,10 +224,10 @@ class SensirionI2cSht4x {
      *
      * SHT4x command for a single shot measurement with medium repeatability.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -238,10 +239,10 @@ class SensirionI2cSht4x {
      *
      * SHT4x command for a single shot measurement with lowest repeatability.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -254,10 +255,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate highest heater power and perform a single shot
      * high precision measurement for 1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -270,10 +271,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate highest heater power and perform a single shot
      * high precision measurement for 0.1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -286,10 +287,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate medium heater power and perform a single shot
      * high precision measurement for 1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -302,10 +303,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate medium heater power and perform a single shot
      * high precision measurement for 0.1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by 
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -318,10 +319,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate lowest heater power and perform a single shot
      * high precision measurement for 1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by 
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */
@@ -334,10 +335,10 @@ class SensirionI2cSht4x {
      * SHT4x command to activate lowest heater power and perform a single shot
      * high precision measurement for 0.1s.
      *
-     * @param[out] temperatureTicks Temperature ticks. Convert to degrees celsius by 
-     * (175 * value / 65535) - 45
-     * @param[out] humidityTicks Humidity ticks. Convert to percent relative humdity by
-     * (125 * value / 65535) - 6
+     * @param[out] temperatureTicks Temperature ticks. Convert to degrees
+     * celsius by (175 * value / 65535) - 45
+     * @param[out] humidityTicks Humidity ticks. Convert to percent relative
+     * humdity by (125 * value / 65535) - 6
      *
      * @return error_code 0 on success, an error code otherwise.
      */

--- a/src/SensirionI2cSht4x.h
+++ b/src/SensirionI2cSht4x.h
@@ -41,12 +41,12 @@
 #include <SensirionErrors.h>
 #include <Wire.h>
 
-static constexpr uint8_t SHT40_I2C_ADDR_44 = 0x44;
-static constexpr uint8_t SHT40_I2C_ADDR_45 = 0x45;
-static constexpr uint8_t SHT41_I2C_ADDR_44 = 0x44;
-static constexpr uint8_t SHT41_I2C_ADDR_45 = 0x45;
-static constexpr uint8_t SHT45_I2C_ADDR_44 = 0x44;
-static constexpr uint8_t SHT45_I2C_ADDR_45 = 0x45;
+constexpr uint8_t SHT40_I2C_ADDR_44 = 0x44;
+constexpr uint8_t SHT40_I2C_ADDR_45 = 0x45;
+constexpr uint8_t SHT41_I2C_ADDR_44 = 0x44;
+constexpr uint8_t SHT41_I2C_ADDR_45 = 0x45;
+constexpr uint8_t SHT45_I2C_ADDR_44 = 0x44;
+constexpr uint8_t SHT45_I2C_ADDR_45 = 0x45;
 
 class SensirionI2cSht4x {
     typedef typeof(Wire) TwoWire;

--- a/src/SensirionI2cSht4x.h
+++ b/src/SensirionI2cSht4x.h
@@ -49,7 +49,7 @@ constexpr uint8_t SHT45_I2C_ADDR_44 = 0x44;
 constexpr uint8_t SHT45_I2C_ADDR_45 = 0x45;
 
 class SensirionI2cSht4x {
-    typedef typeof(Wire) TwoWire;
+    using TwoWire = decltype(Wire);
   public:
     SensirionI2cSht4x();
     /**

--- a/src/SensirionI2cSht4x.h
+++ b/src/SensirionI2cSht4x.h
@@ -38,9 +38,6 @@
 
 #pragma once
 
-#ifndef SENSIRIONI2CSHT4X_H
-#define SENSIRIONI2CSHT4X_H
-
 #include <SensirionErrors.h>
 #include <Wire.h>
 
@@ -400,5 +397,3 @@ class SensirionI2cSht4x {
     TwoWire* _i2cBus = nullptr;
     uint8_t _i2cAddress = 0;
 };
-
-#endif  // SENSIRIONI2CSHT4X_H


### PR DESCRIPTION
I found several code quality issues in SensirionI2cSht4x.h and .cpp files:

SensirionI2cSht4x.h:
- Remove redundant static from file-scope constexpr constants
- Remove redundant #ifndef include guard, #pragma once is sufficient
- Replace non-standard GCC typeof with standard C++ decltype 

SensirionI2cSht4x.cpp:
- Replace typedef enum (C style) with typed enum : uint8_t (C++)
- Replace magic number command IDs with SHT4xCmdId enum values
- Replace implicit double literals with float suffix
- Simplify signal conversion functions to single return statement

No functional change.